### PR TITLE
FIX:재고 페이지 테이블 칼럼숨김/관리

### DIFF
--- a/ERP/src/components/common/ColumnSettingsModal.tsx
+++ b/ERP/src/components/common/ColumnSettingsModal.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { IoMdSettings } from 'react-icons/io';
+import type { TableColumn } from '../../types/tableColumns';
+
+interface ColumnSettingsModalProps {
+  columns: TableColumn[];
+  columnVisibility: Record<string, boolean>;
+  onToggleColumn: (columnId: string) => void;
+  onShowAll: () => void;
+  onReset: () => void;
+}
+
+const ColumnSettingsModal = ({
+  columns,
+  columnVisibility,
+  onToggleColumn,
+  onShowAll,
+  onReset,
+}: ColumnSettingsModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleToggle = (columnId: string) => {
+    const column = columns.find((col) => col.id === columnId);
+    if (column?.required) {
+      return; // 필수 컬럼은 토글 불가
+    }
+    onToggleColumn(columnId);
+  };
+
+  return (
+    <>
+      {/* 설정 버튼 */}
+      <button
+        onClick={() => setIsOpen(true)}
+        className='flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50'
+        title='컬럼 설정'>
+        <IoMdSettings size={18} />
+        <span>컬럼 설정</span>
+      </button>
+
+      {/* 모달 */}
+      {isOpen && (
+        <div
+          className='fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm'
+          onClick={() => setIsOpen(false)}>
+          <div
+            className='w-full max-w-md rounded-lg bg-white p-6 shadow-xl'
+            onClick={(e) => e.stopPropagation()}>
+            {/* 헤더 */}
+            <div className='mb-4 flex items-center justify-between'>
+              <h2 className='text-xl font-semibold text-gray-900'>컬럼 표시 설정</h2>
+              <button
+                onClick={() => setIsOpen(false)}
+                className='text-gray-400 transition-colors hover:text-gray-600'>
+                <svg className='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M6 18L18 6M6 6l12 12'
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* 컬럼 리스트 */}
+            <div className='mb-4 max-h-96 overflow-y-auto'>
+              <div className='space-y-2'>
+                {columns.map((column) => {
+                  const isVisible = columnVisibility[column.id] ?? true;
+                  const isRequired = column.required ?? false;
+
+                  return (
+                    <label
+                      key={column.id}
+                      className={`flex items-center gap-3 rounded-lg border p-3 transition-colors ${
+                        isRequired
+                          ? 'border-gray-200 bg-gray-50 cursor-not-allowed'
+                          : 'border-gray-200 bg-white cursor-pointer hover:bg-gray-50'
+                      }`}>
+                      <input
+                        type='checkbox'
+                        checked={isVisible}
+                        onChange={() => handleToggle(column.id)}
+                        disabled={isRequired}
+                        className='h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 disabled:cursor-not-allowed'
+                      />
+                      <span className={`flex-1 text-sm ${isRequired ? 'text-gray-500' : 'text-gray-900'}`}>
+                        {column.label}
+                        {isRequired && (
+                          <span className='ml-2 text-xs text-gray-400'>(필수)</span>
+                        )}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* 액션 버튼 */}
+            <div className='flex items-center justify-between gap-3 border-t border-gray-200 pt-4'>
+              <div className='flex gap-2'>
+                <button
+                  onClick={onShowAll}
+                  className='rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50'>
+                  모두 표시
+                </button>
+                <button
+                  onClick={onReset}
+                  className='rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50'>
+                  기본값 복원
+                </button>
+              </div>
+              <button
+                onClick={() => setIsOpen(false)}
+                className='rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700'>
+                닫기
+                </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ColumnSettingsModal;
+

--- a/ERP/src/components/inventorytable/InventoryTable.tsx
+++ b/ERP/src/components/inventorytable/InventoryTable.tsx
@@ -6,6 +6,9 @@ import { HiArrowUp } from 'react-icons/hi';
 import { useNavigate } from 'react-router-dom';
 import type { ApiProductVariant } from '../../hooks/queries/useInventories';
 import type { components } from '../../types/api';
+import { useColumnVisibility } from '../../hooks/useColumnVisibility';
+import ColumnSettingsModal from '../common/ColumnSettingsModal';
+import type { TableColumn } from '../../types/tableColumns';
 
 // ProductVariant 타입 별칭
 type ProductVariant = components['schemas']['ProductVariant'];
@@ -67,6 +70,23 @@ const getStatusStyle = (status: string): string => {
   }
 };
 
+// 컬럼 정의
+const INVENTORY_COLUMNS: TableColumn[] = [
+  { id: 'product_id', label: '상품코드', defaultVisible: false },
+  { id: 'variant_code', label: '품목코드', required: true },
+  { id: 'offline_name', label: '오프라인명', defaultVisible: true },
+  { id: 'online_name', label: '온라인명', defaultVisible: false },
+  { id: 'big_category', label: '대분류', defaultVisible: false },
+  { id: 'middle_category', label: '중분류', defaultVisible: false },
+  { id: 'category', label: '카테고리', defaultVisible: false },
+  { id: 'option', label: '옵션', defaultVisible: false },
+  { id: 'detail_option', label: '상세 옵션', defaultVisible: false },
+  { id: 'price', label: '판매가', defaultVisible: true },
+  { id: 'stock', label: '재고(최소재고)', defaultVisible: true },
+  { id: 'status', label: '상태', defaultVisible: true },
+  { id: 'actions', label: '관리', required: true },
+];
+
 const InventoryTable = ({
   inventories,
   onDelete,
@@ -87,6 +107,13 @@ const InventoryTable = ({
     key: 'product_id',
     order: null,
   });
+
+  // 컬럼 표시/숨김 관리
+  const { columnVisibility, toggleColumn, showAllColumns, resetToDefault, isColumnVisible } =
+    useColumnVisibility({
+      columns: INVENTORY_COLUMNS,
+      tableType: 'inventory',
+    });
 
   useEffect(() => {
     if (!Array.isArray(inventories)) return;
@@ -295,6 +322,13 @@ const InventoryTable = ({
           <span className='text-sm'>
             총 {infiniteScroll.totalCount}개 상품 ({infiniteScroll.totalLoaded}개 로딩됨)
           </span>
+          <ColumnSettingsModal
+            columns={INVENTORY_COLUMNS}
+            columnVisibility={columnVisibility}
+            onToggleColumn={toggleColumn}
+            onShowAll={showAllColumns}
+            onReset={resetToDefault}
+          />
           <MdOutlineDownload
             className='cursor-pointer hover:text-gray-700'
             size={20}
@@ -304,75 +338,99 @@ const InventoryTable = ({
       </div>
 
       {/* 테이블 */}
-      <div className='relative w-full overflow-x-auto sm:rounded-lg' style={{ maxWidth: '100%' }}>
-        <table
-          className='w-full border-collapse text-sm text-gray-700'
-          style={{ minWidth: '2000px' }}>
+      <div className='relative w-full overflow-x-auto sm:rounded-lg'>
+        <table className='w-full border-collapse text-sm text-gray-700'>
           <thead className='border-b border-gray-300 bg-gray-50 text-xs uppercase'>
             <tr>
-              <SortableHeader
-                label='상품코드'
-                sortKey='product_id'
-                sortOrder={sortConfig.key === 'product_id' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='품목코드'
-                sortKey='variant_code'
-                sortOrder={sortConfig.key === 'variant_code' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='오프라인명'
-                sortKey='offline_name'
-                sortOrder={sortConfig.key === 'offline_name' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='온라인명'
-                sortKey='online_name'
-                sortOrder={sortConfig.key === 'online_name' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='대분류'
-                sortKey='big_category'
-                sortOrder={sortConfig.key === 'big_category' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='중분류'
-                sortKey='middle_category'
-                sortOrder={sortConfig.key === 'middle_category' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='카테고리'
-                sortKey='category'
-                sortOrder={sortConfig.key === 'category' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <th className='border-b border-gray-300 px-4 py-3'>옵션</th>
-              <th className='border-b border-gray-300 px-4 py-3'>상세 옵션</th>
-              <SortableHeader
-                label='판매가'
-                sortKey='price'
-                sortOrder={sortConfig.key === 'price' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='재고(최소재고)'
-                sortKey='stock'
-                sortOrder={sortConfig.key === 'stock' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                label='상태'
-                sortKey='status'
-                sortOrder={sortConfig.key === 'status' ? sortConfig.order : null}
-                onSort={handleSort}
-              />
-              <th className='border-b border-gray-300 px-4 py-3'>관리</th>
+              {isColumnVisible('product_id') && (
+                <SortableHeader
+                  label='상품코드'
+                  sortKey='product_id'
+                  sortOrder={sortConfig.key === 'product_id' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('variant_code') && (
+                <SortableHeader
+                  label='품목코드'
+                  sortKey='variant_code'
+                  sortOrder={sortConfig.key === 'variant_code' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('offline_name') && (
+                <SortableHeader
+                  label='오프라인명'
+                  sortKey='offline_name'
+                  sortOrder={sortConfig.key === 'offline_name' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('online_name') && (
+                <SortableHeader
+                  label='온라인명'
+                  sortKey='online_name'
+                  sortOrder={sortConfig.key === 'online_name' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('big_category') && (
+                <SortableHeader
+                  label='대분류'
+                  sortKey='big_category'
+                  sortOrder={sortConfig.key === 'big_category' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('middle_category') && (
+                <SortableHeader
+                  label='중분류'
+                  sortKey='middle_category'
+                  sortOrder={sortConfig.key === 'middle_category' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('category') && (
+                <SortableHeader
+                  label='카테고리'
+                  sortKey='category'
+                  sortOrder={sortConfig.key === 'category' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('option') && (
+                <th className='border-b border-gray-300 px-4 py-3'>옵션</th>
+              )}
+              {isColumnVisible('detail_option') && (
+                <th className='border-b border-gray-300 px-4 py-3'>상세 옵션</th>
+              )}
+              {isColumnVisible('price') && (
+                <SortableHeader
+                  label='판매가'
+                  sortKey='price'
+                  sortOrder={sortConfig.key === 'price' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('stock') && (
+                <SortableHeader
+                  label='재고(최소재고)'
+                  sortKey='stock'
+                  sortOrder={sortConfig.key === 'stock' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('status') && (
+                <SortableHeader
+                  label='상태'
+                  sortKey='status'
+                  sortOrder={sortConfig.key === 'status' ? sortConfig.order : null}
+                  onSort={handleSort}
+                />
+              )}
+              {isColumnVisible('actions') && (
+                <th className='border-b border-gray-300 px-4 py-3'>관리</th>
+              )}
             </tr>
           </thead>
           <tbody>
@@ -382,41 +440,67 @@ const InventoryTable = ({
                 className={`border-b border-gray-200 ${
                   Number(product.stock) < Number(product.min_stock) ? 'bg-red-50' : 'bg-white'
                 }`}>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.product_id}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.variant_code}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.offline_name}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.online_name}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.big_category}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.middle_category}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.category}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.option}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>{product.detail_option}</td>
-                <td className='px-4 py-2 whitespace-nowrap'>
-                  {Number(product.price).toLocaleString()}원
-                </td>
-                <td className='px-4 py-2 whitespace-nowrap'>
-                  {product.stock}EA ({product.min_stock !== undefined ? product.min_stock : '-'})
-                </td>
-                <td className='px-4 py-2 whitespace-nowrap'>
-                  <span
-                    className={`rounded-full px-2 py-1 text-xs font-medium whitespace-nowrap ${getStatusStyle(product.status)}`}>
-                    {product.status}
-                  </span>
-                </td>
-                <td className='px-4 py-2 text-center align-middle whitespace-nowrap'>
-                  <div className='inline-flex items-center justify-center gap-2'>
-                    <MdOutlineEdit
-                      className='cursor-pointer text-indigo-500'
-                      onClick={() => {
-                        navigate(`?edit=${product.variant_id}`);
-                      }}
-                    />
-                    <MdOutlineDelete
-                      className='cursor-pointer text-red-500'
-                      onClick={() => onDelete(product.variant_id)}
-                    />
-                  </div>
-                </td>
+                {isColumnVisible('product_id') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.product_id}</td>
+                )}
+                {isColumnVisible('variant_code') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.variant_code}</td>
+                )}
+                {isColumnVisible('offline_name') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.offline_name}</td>
+                )}
+                {isColumnVisible('online_name') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.online_name}</td>
+                )}
+                {isColumnVisible('big_category') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.big_category}</td>
+                )}
+                {isColumnVisible('middle_category') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.middle_category}</td>
+                )}
+                {isColumnVisible('category') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.category}</td>
+                )}
+                {isColumnVisible('option') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.option}</td>
+                )}
+                {isColumnVisible('detail_option') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>{product.detail_option}</td>
+                )}
+                {isColumnVisible('price') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>
+                    {Number(product.price).toLocaleString()}원
+                  </td>
+                )}
+                {isColumnVisible('stock') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>
+                    {product.stock}EA ({product.min_stock !== undefined ? product.min_stock : '-'})
+                  </td>
+                )}
+                {isColumnVisible('status') && (
+                  <td className='px-4 py-2 whitespace-nowrap'>
+                    <span
+                      className={`rounded-full px-2 py-1 text-xs font-medium whitespace-nowrap ${getStatusStyle(product.status)}`}>
+                      {product.status}
+                    </span>
+                  </td>
+                )}
+                {isColumnVisible('actions') && (
+                  <td className='px-4 py-2 text-center align-middle whitespace-nowrap'>
+                    <div className='inline-flex items-center justify-center gap-2'>
+                      <MdOutlineEdit
+                        className='cursor-pointer text-indigo-500'
+                        onClick={() => {
+                          navigate(`?edit=${product.variant_id}`);
+                        }}
+                      />
+                      <MdOutlineDelete
+                        className='cursor-pointer text-red-500'
+                        onClick={() => onDelete(product.variant_id)}
+                      />
+                    </div>
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/ERP/src/components/table/VariantStatusTable.tsx
+++ b/ERP/src/components/table/VariantStatusTable.tsx
@@ -2,6 +2,9 @@ import { useState, useRef, useEffect } from 'react';
 import { ProductVariantStatus } from '../../types/product';
 import { updateVariantStatus } from '../../api/inventory';
 import { useQueryClient } from '@tanstack/react-query';
+import { useColumnVisibility } from '../../hooks/useColumnVisibility';
+import ColumnSettingsModal from '../common/ColumnSettingsModal';
+import type { TableColumn } from '../../types/tableColumns';
 
 interface VariantStatusTableProps {
   data: ProductVariantStatus[];
@@ -30,6 +33,30 @@ interface AdjustmentStatusItem {
   [key: string]: unknown;
 }
 
+// 컬럼 정의
+const VARIANT_STATUS_COLUMNS: TableColumn[] = [
+  { id: 'big_category', label: '대분류', defaultVisible: false },
+  { id: 'middle_category', label: '중분류', defaultVisible: false },
+  { id: 'category', label: '카테고리', defaultVisible: false },
+  { id: 'description', label: '설명', defaultVisible: false },
+  { id: 'online_name', label: '온라인 품목명', defaultVisible: false },
+  { id: 'offline_name', label: '오프라인 품목명', defaultVisible: true },
+  { id: 'option', label: '옵션', defaultVisible: false },
+  { id: 'detail_option', label: '상세옵션', defaultVisible: false },
+  { id: 'product_code', label: '상품코드', defaultVisible: false },
+  { id: 'variant_code', label: '품목코드', required: true },
+  { id: 'warehouse_stock_start', label: '월초창고재고', defaultVisible: false },
+  { id: 'store_stock_start', label: '월초매장재고', defaultVisible: false },
+  { id: 'initial_stock', label: '기초재고', defaultVisible: true },
+  { id: 'inbound_quantity', label: '당월입고', defaultVisible: true },
+  { id: 'store_sales', label: '매장판매', defaultVisible: true },
+  { id: 'online_sales', label: '온라인판매', defaultVisible: true },
+  { id: 'total_sales', label: '판매합계', defaultVisible: true },
+  { id: 'adjustment_quantity', label: '재고조정수량', defaultVisible: false },
+  { id: 'adjustment_status', label: '재고조정상태', defaultVisible: false },
+  { id: 'ending_stock', label: '기말재고', defaultVisible: true },
+];
+
 const VariantStatusTable: React.FC<VariantStatusTableProps> = ({
   data,
   isLoading,
@@ -43,6 +70,13 @@ const VariantStatusTable: React.FC<VariantStatusTableProps> = ({
   const [editValue, setEditValue] = useState<string>('');
   const [savingCell, setSavingCell] = useState<EditingCell | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // 컬럼 표시/숨김 관리
+  const { columnVisibility, toggleColumn, showAllColumns, resetToDefault, isColumnVisible } =
+    useColumnVisibility({
+      columns: VARIANT_STATUS_COLUMNS,
+      tableType: 'variantStatus',
+    });
 
   // 편집 모드 진입 시 input에 포커스
   useEffect(() => {
@@ -193,290 +227,375 @@ const VariantStatusTable: React.FC<VariantStatusTableProps> = ({
 
   return (
     <div className='w-full overflow-x-auto'>
+      {/* 헤더 */}
+      <div className='mb-4 flex items-center justify-end'>
+        <ColumnSettingsModal
+          columns={VARIANT_STATUS_COLUMNS}
+          columnVisibility={columnVisibility}
+          onToggleColumn={toggleColumn}
+          onShowAll={showAllColumns}
+          onReset={resetToDefault}
+        />
+      </div>
       {/* 테이블 */}
       <div className='rounded-lg border border-gray-200'>
-        <table className='w-full min-w-[1200px] table-auto border-collapse text-xs text-gray-700'>
+        <table className='w-full table-auto border-collapse text-xs text-gray-700'>
           <thead className='bg-gray-50'>
             <tr>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '4%', minWidth: '60px' }}>
-                대분류
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '4%', minWidth: '60px' }}>
-                중분류
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                카테고리
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '8%', minWidth: '120px' }}>
-                설명
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '12%', minWidth: '180px' }}>
-                온라인 품목명
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '12%', minWidth: '180px' }}>
-                오프라인 품목명
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '4%', minWidth: '60px' }}>
-                옵션
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                상세옵션
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '6%', minWidth: '100px' }}>
-                상품코드
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '6%', minWidth: '100px' }}>
-                품목코드
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                월초창고재고
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                월초매장재고
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                기초재고
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                당월입고
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                매장판매
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                온라인판매
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                판매합계
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                재고조정수량
-              </th>
-              <th
-                className='px-1 py-1 text-left text-xs font-medium text-gray-500 uppercase'
-                style={{ width: '8%', minWidth: '120px' }}>
-                재고조정상태
-              </th>
-              <th
-                className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
-                style={{ width: '5%', minWidth: '80px' }}>
-                기말재고
-              </th>
+              {isColumnVisible('big_category') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '4%', minWidth: '60px' }}>
+                  대분류
+                </th>
+              )}
+              {isColumnVisible('middle_category') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '4%', minWidth: '60px' }}>
+                  중분류
+                </th>
+              )}
+              {isColumnVisible('category') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  카테고리
+                </th>
+              )}
+              {isColumnVisible('description') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '8%', minWidth: '120px' }}>
+                  설명
+                </th>
+              )}
+              {isColumnVisible('online_name') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '12%', minWidth: '180px' }}>
+                  온라인 품목명
+                </th>
+              )}
+              {isColumnVisible('offline_name') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '12%', minWidth: '180px' }}>
+                  오프라인 품목명
+                </th>
+              )}
+              {isColumnVisible('option') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '4%', minWidth: '60px' }}>
+                  옵션
+                </th>
+              )}
+              {isColumnVisible('detail_option') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  상세옵션
+                </th>
+              )}
+              {isColumnVisible('product_code') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '6%', minWidth: '100px' }}>
+                  상품코드
+                </th>
+              )}
+              {isColumnVisible('variant_code') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '6%', minWidth: '100px' }}>
+                  품목코드
+                </th>
+              )}
+              {isColumnVisible('warehouse_stock_start') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  월초창고재고
+                </th>
+              )}
+              {isColumnVisible('store_stock_start') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  월초매장재고
+                </th>
+              )}
+              {isColumnVisible('initial_stock') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  기초재고
+                </th>
+              )}
+              {isColumnVisible('inbound_quantity') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  당월입고
+                </th>
+              )}
+              {isColumnVisible('store_sales') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  매장판매
+                </th>
+              )}
+              {isColumnVisible('online_sales') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  온라인판매
+                </th>
+              )}
+              {isColumnVisible('total_sales') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  판매합계
+                </th>
+              )}
+              {isColumnVisible('adjustment_quantity') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  재고조정수량
+                </th>
+              )}
+              {isColumnVisible('adjustment_status') && (
+                <th
+                  className='px-1 py-1 text-left text-xs font-medium text-gray-500 uppercase'
+                  style={{ width: '8%', minWidth: '120px' }}>
+                  재고조정상태
+                </th>
+              )}
+              {isColumnVisible('ending_stock') && (
+                <th
+                  className='px-1 py-1 text-right text-xs font-medium whitespace-nowrap text-gray-500 uppercase'
+                  style={{ width: '5%', minWidth: '80px' }}>
+                  기말재고
+                </th>
+              )}
             </tr>
           </thead>
           <tbody className='divide-y divide-gray-200 bg-white'>
             {data.map((item, index) => (
               <tr key={`${item.variant_code}-${index}`} className='hover:bg-gray-50'>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title='클릭하여 상품 상세보기'
-                  style={{ width: '4%', minWidth: '60px' }}>
-                  {item.big_category}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title='클릭하여 상품 상세보기'
-                  style={{ width: '4%', minWidth: '60px' }}>
-                  {item.middle_category}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title='클릭하여 상품 상세보기'
-                  style={{ width: '5%', minWidth: '80px' }}>
-                  {item.category}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title={`${item.description} - 클릭하여 상품 상세보기`}
-                  style={{ width: '8%', minWidth: '120px' }}>
-                  {item.description}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title={`${item.online_name} - 클릭하여 상품 상세보기`}
-                  style={{ width: '12%', minWidth: '180px' }}>
-                  {item.online_name}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title={`${item.offline_name} - 클릭하여 상품 상세보기`}
-                  style={{ width: '12%', minWidth: '180px' }}>
-                  {item.offline_name}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title='클릭하여 상품 상세보기'
-                  style={{ width: '4%', minWidth: '60px' }}>
-                  {item.option}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title='클릭하여 상품 상세보기'
-                  style={{ width: '5%', minWidth: '80px' }}>
-                  {item.detail_option}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs font-medium whitespace-nowrap text-blue-600 hover:bg-blue-100 hover:text-blue-800 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title='클릭하여 상품 상세보기'
-                  style={{ width: '6%', minWidth: '100px' }}>
-                  {item.product_code}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs font-medium whitespace-nowrap text-indigo-600 hover:bg-indigo-100 hover:text-indigo-800 sm:px-2'
-                  onClick={() => onRowClick?.(item.variant_code || '')}
-                  title='클릭하여 상품 상세보기'
-                  style={{ width: '6%', minWidth: '100px' }}>
-                  {item.variant_code}
-                </td>
-                {renderEditableCell(
-                  index,
-                  'warehouse_stock_start',
-                  item.warehouse_stock_start,
-                  item.variant_code || '',
-                  'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
-                  { width: '5%', minWidth: '80px' }
+                {isColumnVisible('big_category') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title='클릭하여 상품 상세보기'
+                    style={{ width: '4%', minWidth: '60px' }}>
+                    {item.big_category}
+                  </td>
                 )}
-                {renderEditableCell(
-                  index,
-                  'store_stock_start',
-                  item.store_stock_start,
-                  item.variant_code || '',
-                  'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
-                  { width: '5%', minWidth: '80px' }
+                {isColumnVisible('middle_category') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title='클릭하여 상품 상세보기'
+                    style={{ width: '4%', minWidth: '60px' }}>
+                    {item.middle_category}
+                  </td>
                 )}
-                <td
-                  className='px-1 py-2 text-right text-xs whitespace-nowrap text-gray-900 sm:px-2'
-                  style={{ width: '5%', minWidth: '80px' }}>
-                  {item.initial_stock ? Number(item.initial_stock).toLocaleString() : 0}
-                </td>
-                {renderEditableCell(
-                  index,
-                  'inbound_quantity',
-                  item.inbound_quantity,
-                  item.variant_code || '',
-                  'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
-                  { width: '5%', minWidth: '80px' }
+                {isColumnVisible('category') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title='클릭하여 상품 상세보기'
+                    style={{ width: '5%', minWidth: '80px' }}>
+                    {item.category}
+                  </td>
                 )}
-                {renderEditableCell(
-                  index,
-                  'store_sales',
-                  item.store_sales,
-                  item.variant_code || '',
-                  'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
-                  { width: '5%', minWidth: '80px' }
+                {isColumnVisible('description') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title={`${item.description} - 클릭하여 상품 상세보기`}
+                    style={{ width: '8%', minWidth: '120px' }}>
+                    {item.description}
+                  </td>
                 )}
-                {renderEditableCell(
-                  index,
-                  'online_sales',
-                  item.online_sales,
-                  item.variant_code || '',
-                  'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
-                  { width: '5%', minWidth: '80px' }
+                {isColumnVisible('online_name') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title={`${item.online_name} - 클릭하여 상품 상세보기`}
+                    style={{ width: '12%', minWidth: '180px' }}>
+                    {item.online_name}
+                  </td>
                 )}
-                <td
-                  className='px-1 py-2 text-right text-xs font-medium whitespace-nowrap text-gray-900 sm:px-2'
-                  style={{ width: '5%', minWidth: '80px' }}>
-                  {item.total_sales?.toLocaleString() || 0}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-right text-xs whitespace-nowrap text-gray-900 transition-colors hover:bg-blue-50 sm:px-2'
-                  style={{ width: '5%', minWidth: '80px' }}
-                  onClick={() => onStockAdjust?.(item)}
-                  title='클릭하여 재고 조정'>
-                  {item.adjustment_quantity ? Number(item.adjustment_quantity).toLocaleString() : 0}
-                </td>
-                <td
-                  className='cursor-pointer px-1 py-2 text-xs text-gray-900 transition-colors hover:bg-blue-50 sm:px-2'
-                  style={{ width: '8%' }}
-                  onClick={() => onStockAdjust?.(item)}
-                  title='클릭하여 재고 조정'>
-                  <div className='whitespace-pre-line'>
-                    {(() => {
-                      const adjustmentStatus = item.adjustment_status;
-                      if (typeof adjustmentStatus === 'string') {
-                        // 쉼표로 구분된 문자열인 경우 줄바꿈 처리
-                        return adjustmentStatus.split(',').join('\n');
-                      }
-                      if (adjustmentStatus) {
-                        try {
-                          // JSON 문자열인 경우 파싱 시도
-                          let parsed: unknown;
-                          if (typeof adjustmentStatus === 'string') {
-                            parsed = JSON.parse(adjustmentStatus);
-                          } else {
-                            parsed = adjustmentStatus;
-                          }
-
-                          const statusArray = Array.isArray(parsed) ? parsed : [parsed];
-                          return statusArray
-                            .map((status: unknown) => {
-                              if (typeof status === 'object' && status) {
-                                const statusItem = status as AdjustmentStatusItem;
-                                const createdBy = statusItem.created_by || '';
-                                const quantity = statusItem.quantity || 0;
-                                return `${createdBy}: ${quantity > 0 ? '+' : ''}${quantity}`;
-                              }
-                              return String(status);
-                            })
-                            .join('\n');
-                        } catch {
-                          return String(adjustmentStatus);
+                {isColumnVisible('offline_name') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title={`${item.offline_name} - 클릭하여 상품 상세보기`}
+                    style={{ width: '12%', minWidth: '180px' }}>
+                    {item.offline_name}
+                  </td>
+                )}
+                {isColumnVisible('option') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title='클릭하여 상품 상세보기'
+                    style={{ width: '4%', minWidth: '60px' }}>
+                    {item.option}
+                  </td>
+                )}
+                {isColumnVisible('detail_option') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs whitespace-nowrap text-gray-900 hover:bg-blue-50 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title='클릭하여 상품 상세보기'
+                    style={{ width: '5%', minWidth: '80px' }}>
+                    {item.detail_option}
+                  </td>
+                )}
+                {isColumnVisible('product_code') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs font-medium whitespace-nowrap text-blue-600 hover:bg-blue-100 hover:text-blue-800 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title='클릭하여 상품 상세보기'
+                    style={{ width: '6%', minWidth: '100px' }}>
+                    {item.product_code}
+                  </td>
+                )}
+                {isColumnVisible('variant_code') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs font-medium whitespace-nowrap text-indigo-600 hover:bg-indigo-100 hover:text-indigo-800 sm:px-2'
+                    onClick={() => onRowClick?.(item.variant_code || '')}
+                    title='클릭하여 상품 상세보기'
+                    style={{ width: '6%', minWidth: '100px' }}>
+                    {item.variant_code}
+                  </td>
+                )}
+                {isColumnVisible('warehouse_stock_start') &&
+                  renderEditableCell(
+                    index,
+                    'warehouse_stock_start',
+                    item.warehouse_stock_start,
+                    item.variant_code || '',
+                    'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
+                    { width: '5%', minWidth: '80px' }
+                  )}
+                {isColumnVisible('store_stock_start') &&
+                  renderEditableCell(
+                    index,
+                    'store_stock_start',
+                    item.store_stock_start,
+                    item.variant_code || '',
+                    'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
+                    { width: '5%', minWidth: '80px' }
+                  )}
+                {isColumnVisible('initial_stock') && (
+                  <td
+                    className='px-1 py-2 text-right text-xs whitespace-nowrap text-gray-900 sm:px-2'
+                    style={{ width: '5%', minWidth: '80px' }}>
+                    {item.initial_stock ? Number(item.initial_stock).toLocaleString() : 0}
+                  </td>
+                )}
+                {isColumnVisible('inbound_quantity') &&
+                  renderEditableCell(
+                    index,
+                    'inbound_quantity',
+                    item.inbound_quantity,
+                    item.variant_code || '',
+                    'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
+                    { width: '5%', minWidth: '80px' }
+                  )}
+                {isColumnVisible('store_sales') &&
+                  renderEditableCell(
+                    index,
+                    'store_sales',
+                    item.store_sales,
+                    item.variant_code || '',
+                    'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
+                    { width: '5%', minWidth: '80px' }
+                  )}
+                {isColumnVisible('online_sales') &&
+                  renderEditableCell(
+                    index,
+                    'online_sales',
+                    item.online_sales,
+                    item.variant_code || '',
+                    'px-1 sm:px-2 py-2 text-right text-xs text-gray-900',
+                    { width: '5%', minWidth: '80px' }
+                  )}
+                {isColumnVisible('total_sales') && (
+                  <td
+                    className='px-1 py-2 text-right text-xs font-medium whitespace-nowrap text-gray-900 sm:px-2'
+                    style={{ width: '5%', minWidth: '80px' }}>
+                    {item.total_sales?.toLocaleString() || 0}
+                  </td>
+                )}
+                {isColumnVisible('adjustment_quantity') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-right text-xs whitespace-nowrap text-gray-900 transition-colors hover:bg-blue-50 sm:px-2'
+                    style={{ width: '5%', minWidth: '80px' }}
+                    onClick={() => onStockAdjust?.(item)}
+                    title='클릭하여 재고 조정'>
+                    {item.adjustment_quantity ? Number(item.adjustment_quantity).toLocaleString() : 0}
+                  </td>
+                )}
+                {isColumnVisible('adjustment_status') && (
+                  <td
+                    className='cursor-pointer px-1 py-2 text-xs text-gray-900 transition-colors hover:bg-blue-50 sm:px-2'
+                    style={{ width: '8%' }}
+                    onClick={() => onStockAdjust?.(item)}
+                    title='클릭하여 재고 조정'>
+                    <div className='whitespace-pre-line'>
+                      {(() => {
+                        const adjustmentStatus = item.adjustment_status;
+                        if (typeof adjustmentStatus === 'string') {
+                          // 쉼표로 구분된 문자열인 경우 줄바꿈 처리
+                          return adjustmentStatus.split(',').join('\n');
                         }
-                      }
-                      return '-';
-                    })()}
-                  </div>
-                </td>
-                <td
-                  className='px-1 py-2 text-right text-xs font-medium whitespace-nowrap text-green-600 sm:px-2'
-                  style={{ width: '5%', minWidth: '80px' }}>
-                  {item.ending_stock?.toLocaleString() || 0}
-                </td>
+                        if (adjustmentStatus) {
+                          try {
+                            // JSON 문자열인 경우 파싱 시도
+                            let parsed: unknown;
+                            if (typeof adjustmentStatus === 'string') {
+                              parsed = JSON.parse(adjustmentStatus);
+                            } else {
+                              parsed = adjustmentStatus;
+                            }
+
+                            const statusArray = Array.isArray(parsed) ? parsed : [parsed];
+                            return statusArray
+                              .map((status: unknown) => {
+                                if (typeof status === 'object' && status) {
+                                  const statusItem = status as AdjustmentStatusItem;
+                                  const createdBy = statusItem.created_by || '';
+                                  const quantity = statusItem.quantity || 0;
+                                  return `${createdBy}: ${quantity > 0 ? '+' : ''}${quantity}`;
+                                }
+                                return String(status);
+                              })
+                              .join('\n');
+                          } catch {
+                            return String(adjustmentStatus);
+                          }
+                        }
+                        return '-';
+                      })()}
+                    </div>
+                  </td>
+                )}
+                {isColumnVisible('ending_stock') && (
+                  <td
+                    className='px-1 py-2 text-right text-xs font-medium whitespace-nowrap text-green-600 sm:px-2'
+                    style={{ width: '5%', minWidth: '80px' }}>
+                    {item.ending_stock?.toLocaleString() || 0}
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/ERP/src/hooks/useColumnVisibility.ts
+++ b/ERP/src/hooks/useColumnVisibility.ts
@@ -1,0 +1,110 @@
+import { useState, useEffect, useCallback } from 'react';
+import { loadColumnVisibility, saveColumnVisibility } from '../utils/localStorage';
+import type { TableColumn, ColumnVisibility, TableType } from '../types/tableColumns';
+
+interface UseColumnVisibilityOptions {
+  columns: TableColumn[];
+  tableType: TableType;
+}
+
+export const useColumnVisibility = ({ columns, tableType }: UseColumnVisibilityOptions) => {
+  // 초기 표시 상태 생성 (기본값: 모든 컬럼 표시)
+  const getInitialVisibility = useCallback((): ColumnVisibility => {
+    const stored = loadColumnVisibility(tableType);
+    if (stored) {
+      // 저장된 설정이 있으면 사용하되, 새로 추가된 컬럼은 기본값으로 추가
+      const visibility: ColumnVisibility = {};
+      columns.forEach((col) => {
+        visibility[col.id] = stored[col.id] ?? col.defaultVisible ?? true;
+      });
+      return visibility;
+    }
+    // 저장된 설정이 없으면 기본값 사용
+    const visibility: ColumnVisibility = {};
+    columns.forEach((col) => {
+      visibility[col.id] = col.defaultVisible ?? true;
+    });
+    return visibility;
+  }, [columns, tableType]);
+
+  const [columnVisibility, setColumnVisibility] = useState<ColumnVisibility>(getInitialVisibility);
+
+  // localStorage에서 설정 로드
+  useEffect(() => {
+    const stored = loadColumnVisibility(tableType);
+    if (stored) {
+      const visibility: ColumnVisibility = {};
+      columns.forEach((col) => {
+        visibility[col.id] = stored[col.id] ?? col.defaultVisible ?? true;
+      });
+      setColumnVisibility(visibility);
+    }
+  }, [columns, tableType]);
+
+  // 컬럼 표시/숨김 토글
+  const toggleColumn = useCallback(
+    (columnId: string) => {
+      const column = columns.find((col) => col.id === columnId);
+      if (!column || column.required) {
+        // 필수 컬럼은 숨길 수 없음
+        return;
+      }
+
+      setColumnVisibility((prev) => {
+        const newVisibility = {
+          ...prev,
+          [columnId]: !prev[columnId],
+        };
+
+        // 최소 1개 이상의 컬럼은 표시되어야 함
+        const visibleCount = Object.values(newVisibility).filter((v) => v).length;
+        if (visibleCount === 0) {
+          // 모든 컬럼을 숨기려고 하면 원래대로 복원
+          return prev;
+        }
+
+        // localStorage에 저장
+        saveColumnVisibility(tableType, newVisibility);
+        return newVisibility;
+      });
+    },
+    [columns, tableType]
+  );
+
+  // 모든 컬럼 표시
+  const showAllColumns = useCallback(() => {
+    const visibility: ColumnVisibility = {};
+    columns.forEach((col) => {
+      visibility[col.id] = true;
+    });
+    setColumnVisibility(visibility);
+    saveColumnVisibility(tableType, visibility);
+  }, [columns, tableType]);
+
+  // 기본값으로 복원
+  const resetToDefault = useCallback(() => {
+    const visibility: ColumnVisibility = {};
+    columns.forEach((col) => {
+      visibility[col.id] = col.defaultVisible ?? true;
+    });
+    setColumnVisibility(visibility);
+    saveColumnVisibility(tableType, visibility);
+  }, [columns, tableType]);
+
+  // 특정 컬럼이 표시되는지 확인
+  const isColumnVisible = useCallback(
+    (columnId: string) => {
+      return columnVisibility[columnId] ?? true;
+    },
+    [columnVisibility]
+  );
+
+  return {
+    columnVisibility,
+    toggleColumn,
+    showAllColumns,
+    resetToDefault,
+    isColumnVisible,
+  };
+};
+

--- a/ERP/src/types/tableColumns.ts
+++ b/ERP/src/types/tableColumns.ts
@@ -1,0 +1,14 @@
+// 테이블 컬럼 정의 타입
+export interface TableColumn {
+  id: string;
+  label: string;
+  required?: boolean; // 필수 컬럼 (항상 표시되어야 함)
+  defaultVisible?: boolean; // 기본 표시 여부
+}
+
+// 컬럼 표시 상태 타입
+export type ColumnVisibility = Record<string, boolean>;
+
+// 테이블 타입
+export type TableType = 'inventory' | 'variantStatus';
+

--- a/ERP/src/utils/localStorage.ts
+++ b/ERP/src/utils/localStorage.ts
@@ -59,3 +59,39 @@ export const setTokens = (accessToken: string, refreshToken: string) => {
   setAccessToken(accessToken);
   setRefreshToken(refreshToken);
 };
+
+// 컬럼 설정 관리 함수들
+const INVENTORY_TABLE_COLUMNS_KEY = 'inventoryTableColumns';
+const VARIANT_STATUS_TABLE_COLUMNS_KEY = 'variantStatusTableColumns';
+
+// 컬럼 설정 저장
+export const saveColumnVisibility = (tableType: 'inventory' | 'variantStatus', visibility: Record<string, boolean>) => {
+  try {
+    const key = tableType === 'inventory' ? INVENTORY_TABLE_COLUMNS_KEY : VARIANT_STATUS_TABLE_COLUMNS_KEY;
+    localStorage.setItem(key, JSON.stringify(visibility));
+  } catch (error) {
+    console.error('컬럼 설정 저장 실패:', error);
+  }
+};
+
+// 컬럼 설정 로드
+export const loadColumnVisibility = (tableType: 'inventory' | 'variantStatus'): Record<string, boolean> | null => {
+  try {
+    const key = tableType === 'inventory' ? INVENTORY_TABLE_COLUMNS_KEY : VARIANT_STATUS_TABLE_COLUMNS_KEY;
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : null;
+  } catch (error) {
+    console.error('컬럼 설정 로드 실패:', error);
+    return null;
+  }
+};
+
+// 컬럼 설정 초기화 (삭제)
+export const clearColumnVisibility = (tableType: 'inventory' | 'variantStatus') => {
+  try {
+    const key = tableType === 'inventory' ? INVENTORY_TABLE_COLUMNS_KEY : VARIANT_STATUS_TABLE_COLUMNS_KEY;
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.error('컬럼 설정 삭제 실패:', error);
+  }
+};


### PR DESCRIPTION
<!-- PR의 제목은 다음과 같은 규칙으로 작성해주세요 -->
<!-- "[파트] {도메인명} > {작업내용} #{이슈번호}" -->
<!-- 예시: "[BE] Helper > 회원가입 시 로그인 처리 #31" -->


## Checklist

- [ ] 🌿 Base 브랜치를 올바르게 설정했나요?
- [ ] 📝 PR 제목이 규칙에 맞게 작성되었나요?
- [ ] ✅ 빌드와 테스트는 모두 성공했나요?
- [ ] 📦 코드의 책임이 명확하게 분리되었나요?
- [ ] ⚠️ 예외 상황에 대한 처리가 적절하게 이루어졌나요?
- [ ] 🧹 불필요한 코드를 제거했나요? (예: console.log)
- [ ] 👥 리뷰어를 지정했나요?

---

## 🧪 Test Method

- [ ] 수동 테스트 통과

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 재고관리 탭별 표시 칼럼 관리 기능
- 상품 관리 : 
품목코드 | 오프라인명 | 판매가 | 재고(최소재고) | 상태 | 관리
- 월별 재고 현황 : 오프라인 품목명/품목코드/
기초재고 | 당월입고 | 매장판매 | 온라인판매 | 판매합계 | 기말재고

- 컬럼 설정 버튼을 통해 표시할 컬럼 설정 가능

---


## 📢 To Reviewers

-

## 📸 Screenshot or Video (Optional)

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
